### PR TITLE
panic fix: no version histories is mutable state

### DIFF
--- a/service/history/engine/engineimpl/history_engine_test.go
+++ b/service/history/engine/engineimpl/history_engine_test.go
@@ -264,6 +264,42 @@ func (s *engineSuite) TestGetMutableState_EmptyRunID() {
 	s.Equal(&types.EntityNotExistsError{}, err)
 }
 
+func (s *engineSuite) TestGetMutableState_NoVersionHistories() {
+	ctx := context.Background()
+
+	workflowExecution := types.WorkflowExecution{
+		WorkflowID: "test-get-workflow-execution-event-id",
+		RunID:      constants.TestRunID,
+	}
+
+	msBuilder := execution.NewMutableStateBuilderWithEventV2(
+		s.mockHistoryEngine.shard,
+		testlogger.New(s.Suite.T()),
+		workflowExecution.GetRunID(),
+		constants.TestLocalDomainEntry,
+	)
+
+	// simulate having no version histories
+	s.Require().NoError(msBuilder.SetVersionHistories(nil))
+
+	ms := execution.CreatePersistenceMutableState(s.T(), msBuilder)
+	gweResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
+	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(gweResponse, nil).Once()
+
+	// return immediately, since the expected next event ID appears
+	_, err := s.mockHistoryEngine.GetMutableState(ctx, &types.GetMutableStateRequest{
+		DomainUUID: constants.TestDomainID,
+		Execution:  &workflowExecution,
+
+		// we request for the specific history version, but there are no history versions for the execution
+		VersionHistoryItem: &types.VersionHistoryItem{
+			EventID: 1,
+			Version: 1,
+		},
+	})
+	s.ErrorContains(err, "no version histories exist")
+}
+
 func (s *engineSuite) TestGetMutableStateLongPoll() {
 	ctx := context.Background()
 

--- a/service/history/engine/engineimpl/poll_mutable_state.go
+++ b/service/history/engine/engineimpl/poll_mutable_state.go
@@ -160,6 +160,15 @@ func (e *historyEngineImpl) getMutableStateOrLongPoll(
 		return nil, err
 	}
 
+	if response.GetVersionHistories() == nil {
+		e.logger.Warn("current version history does not exist",
+			tag.Dynamic("requested-version-history", request.VersionHistoryItem),
+		)
+		return nil, &types.CurrentBranchChangedError{
+			Message: "current branch not found - no version histories exist",
+		}
+	}
+
 	currentVersionHistory, err := persistence.NewVersionHistoriesFromInternalType(
 		response.GetVersionHistories(),
 	).GetCurrentVersionHistory()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Handle error if version histories is nil instead of calling a method (`GetCurrentVersionHistory`) on a nil pointer.
While returning an empty version histories might look like a good alternative, is not since everywhere in code we expect versions to be not empty. In addition, version histories also has index and it should always be valid (`0` refers to `histories[0]`).

<!-- Tell your future self why have you made these changes -->
**Why?**
Because of panics in Uber production.

Having no version histories is considered OK by `getMutableState` which has:
```
if versionHistories != nil {
        retResp.VersionHistories = versionHistories.ToInternalType()
}
```

Which means, PollMutableState/GetMutableState should not panic on this. It is now returning error.
Could make it even better and handle case when initially there were no versions history, and then appeared, but:
a) an error instead of panic-ing is already better b) this will complicate tests
c) still not sure how valid this case is (isn't that a corrupted execution?)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added a new unit-test


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
